### PR TITLE
feat: add controller for wallet-history, response dto

### DIFF
--- a/src/main/java/com/imaging/app/controller/WalletHistoryController.java
+++ b/src/main/java/com/imaging/app/controller/WalletHistoryController.java
@@ -1,0 +1,37 @@
+package com.imaging.app.controller;
+
+import com.imaging.app.dto.WalletHistoryResponseDto;
+import com.imaging.app.enums.CreditsChangeType;
+import com.imaging.app.security.AuthUtils;
+import com.imaging.app.service.WalletHistoryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/wallet/history")
+@RequiredArgsConstructor
+public class WalletHistoryController {
+    private final WalletHistoryService walletHistoryService;
+
+    @GetMapping
+    public ResponseEntity<?> getWalletHistory() {
+        String userId = AuthUtils.getAuthenticatedUserId();
+        List<WalletHistoryResponseDto> walletHistories =
+                walletHistoryService.getWalletHistory(userId);
+        return ResponseEntity.ok(walletHistories);
+    }
+
+    @GetMapping("/type")
+    public ResponseEntity<?> getWalletHistoryByType(@RequestParam String type) {
+        String userId = AuthUtils.getAuthenticatedUserId();
+        CreditsChangeType parsedType = CreditsChangeType.from(type);
+        List<WalletHistoryResponseDto> walletHistories =
+                walletHistoryService.getWalletHistoryByType(userId, parsedType);
+        return ResponseEntity.ok(walletHistories);
+    }
+}

--- a/src/main/java/com/imaging/app/dto/WalletHistoryResponseDto.java
+++ b/src/main/java/com/imaging/app/dto/WalletHistoryResponseDto.java
@@ -1,0 +1,28 @@
+package com.imaging.app.dto;
+
+import com.imaging.app.enums.CreditsChangeType;
+import com.imaging.app.model.WalletHistory;
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+public class WalletHistoryResponseDto {
+    private String id;
+    private Double changeInCredits;
+    private CreditsChangeType changeType;
+    private LocalDateTime createdAt;
+
+    public static class Mapper {
+        public static WalletHistoryResponseDto toDto(WalletHistory walletHistory) {
+            WalletHistoryResponseDto dto = new WalletHistoryResponseDto();
+            dto.setId(walletHistory.getId());
+            dto.setChangeType(walletHistory.getChangeType());
+            dto.setChangeInCredits(walletHistory.getChangeInCredits());
+            dto.setCreatedAt(walletHistory.getCreatedAt());
+            return dto;
+        }
+    }
+}

--- a/src/main/java/com/imaging/app/enums/CreditsChangeType.java
+++ b/src/main/java/com/imaging/app/enums/CreditsChangeType.java
@@ -1,8 +1,18 @@
 package com.imaging.app.enums;
 
+import com.imaging.app.exception.CustomIllegalArgumentException;
+
 public enum CreditsChangeType {
     PURCHASE,
     REFUND,
     IMAGE_GENERATION,
-    BONUS,
+    BONUS;
+
+    public static CreditsChangeType from(String value) {
+        try {
+            return CreditsChangeType.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException | NullPointerException ex) {
+            throw new CustomIllegalArgumentException(ex.getMessage());
+        }
+    }
 }

--- a/src/main/java/com/imaging/app/service/WalletHistoryService.java
+++ b/src/main/java/com/imaging/app/service/WalletHistoryService.java
@@ -1,7 +1,7 @@
 package com.imaging.app.service;
 
+import com.imaging.app.dto.WalletHistoryResponseDto;
 import com.imaging.app.enums.CreditsChangeType;
-import com.imaging.app.model.WalletHistory;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
@@ -10,7 +10,8 @@ public interface WalletHistoryService {
     public void createWalletHistory(
             String userId, Double changeInCredits, CreditsChangeType changeType);
 
-    public List<WalletHistory> getWalletHistory(String userId);
+    public List<WalletHistoryResponseDto> getWalletHistory(String userId);
 
-    public List<WalletHistory> getWalletHistoryByType(String userId, CreditsChangeType changeType);
+    public List<WalletHistoryResponseDto> getWalletHistoryByType(
+            String userId, CreditsChangeType changeType);
 }

--- a/src/main/java/com/imaging/app/service/WalletHistoryServiceImpl.java
+++ b/src/main/java/com/imaging/app/service/WalletHistoryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.imaging.app.service;
 
+import com.imaging.app.dto.WalletHistoryResponseDto;
 import com.imaging.app.enums.CreditsChangeType;
 import com.imaging.app.model.WalletHistory;
 import com.imaging.app.repository.WalletHistoryRepository;
@@ -32,12 +33,16 @@ public class WalletHistoryServiceImpl implements WalletHistoryService {
     }
 
     @Override
-    public List<WalletHistory> getWalletHistory(String userId) {
-        return walletHistoryRepository.findByUserId(userId);
+    public List<WalletHistoryResponseDto> getWalletHistory(String userId) {
+        List<WalletHistory> walletHistories = walletHistoryRepository.findByUserId(userId);
+        return walletHistories.stream().map(WalletHistoryResponseDto.Mapper::toDto).toList();
     }
 
     @Override
-    public List<WalletHistory> getWalletHistoryByType(String userId, CreditsChangeType changeType) {
-        return walletHistoryRepository.findByUserIdAndChangeType(userId, changeType);
+    public List<WalletHistoryResponseDto> getWalletHistoryByType(
+            String userId, CreditsChangeType changeType) {
+        List<WalletHistory> walletHistories =
+                walletHistoryRepository.findByUserIdAndChangeType(userId, changeType);
+        return walletHistories.stream().map(WalletHistoryResponseDto.Mapper::toDto).toList();
     }
 }


### PR DESCRIPTION
This pull request introduces a new `WalletHistoryController` to handle wallet history-related API endpoints and refactors the existing service layer to return `WalletHistoryResponseDto` objects instead of `WalletHistory` entities. Additionally, it adds a utility method to the `CreditsChangeType` enum for safer string-to-enum conversion.
